### PR TITLE
feat(ci): pilot PR-tagged GHCR image + kustomize artifacts

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-omni-pitcher,homerun2-omni-pitcher-kustomize
+      dry-run: true
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Pilot consumer for the new reusable workflows in stuttgart-things/github-workflow-templates#78. Validates the PR-preview artifact contract end-to-end before the ApplicationSet wiring lands in stuttgart-things/argocd.

- `build-scan-image.yaml`: PRs now push to `ghcr.io/stuttgart-things/homerun2-omni-pitcher` tagged `pr-<num>-<sha>` + `pr-<num>`. Main push unchanged (still ttl.sh).
- `push-kustomize-pr.yaml` (new): pushes `ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize:pr-<num>-<sha>` via `dagger kcl push-kustomize-base`.
- `cleanup-pr-artifacts.yaml` (new): on PR close, runs the cleanup workflow with `dry-run: true` for the first validation cycle. Flip off in a follow-up once we confirm `GITHUB_TOKEN` has permission to delete the org-level package versions.

## Test plan

- [ ] PR open: both `build-pr` and `push-kustomize` jobs succeed
- [ ] Verify `ghcr.io/stuttgart-things/homerun2-omni-pitcher:pr-<num>-<sha>` exists in the GHCR UI
- [ ] Verify `ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize:pr-<num>-<sha>` exists
- [ ] PR close: cleanup workflow runs in dry-run, lists both versions as candidates
- [ ] Follow-up PR flips `dry-run: false`, validates actual deletion

Refs #108