### PR TITLE
test(ci): flip cleanup dry-run off to validate DELETE permission

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-omni-pitcher,homerun2-omni-pitcher-kustomize
+      dry-run: true
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -12,5 +12,5 @@ jobs:
     with:
       runs-on: ubuntu-latest
       packages: homerun2-omni-pitcher,homerun2-omni-pitcher-kustomize
-      dry-run: true
+      dry-run: false
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Follow-up to #109. Flips \`cleanup-pr-artifacts.yaml\` from \`dry-run: true\` → \`false\` so we can confirm \`GITHUB_TOKEN\` actually has DELETE permission on the org-level GHCR packages.

PR #109's dry-run confirmed listing works; deletion is a separate scope check that only surfaces on the real call.

## Test plan

- [ ] PR open: build-pr + push-kustomize push \`pr-<num>-<sha>\` versions to both packages
- [ ] PR close: cleanup runs (non-dry-run), deletes those versions
- [ ] Confirm deletion in run logs (\`Deleting version <id>\` lines, no 403/404)

Refs #108