### PR TITLE
feat(ci): comment preview URL on PR + document PR preview workflow

### DIFF
--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,58 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const num = context.issue.number;
+            const url = `https://omni-pr-${num}.homerun2-dev.sthings-vsphere.labul.sva.de`;
+            const marker = "<!-- preview-url-bot -->";
+            const body = [
+              marker,
+              "## 🚀 Preview environment",
+              "",
+              `| | |`,
+              `|--|--|`,
+              `| URL | ${url} |`,
+              `| Health | ${url}/health |`,
+              `| Namespace | \`homerun2-pr-${num}\` on \`homerun2-dev\` |`,
+              `| ArgoCD | [\`homerun2-pr-${num}\`](https://argocd.platform.sthings-vsphere.labul.sva.de/applications?search=homerun2-pr-${num}) |`,
+              "",
+              "Spinning up — give it a couple of minutes for image + kustomize OCI builds to publish and for ArgoCD to sync.",
+              "Closing this PR tears the preview down automatically.",
+            ].join("\n");
+
+            // Sticky comment: update on reopen instead of stacking duplicates.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -276,6 +276,24 @@ helmfile apply -f \
 
 </details>
 
+## PR preview environments
+
+Every open PR against `main` gets an ephemeral preview environment on `homerun2-dev` — omni-pitcher + redis-stack in an isolated namespace, reachable end-to-end so reviewers can pitch test events against the PR build.
+
+| Event | What happens |
+|---|---|
+| **PR open / push** | CI builds + pushes `ghcr.io/stuttgart-things/homerun2-omni-pitcher:pr-<num>-<sha>` (image) and `homerun2-omni-pitcher-kustomize:pr-<num>-<sha>` (kustomize OCI). A bot comments the preview URL. |
+| **ArgoCD reconcile** (≤10m) | The `homerun2-omni-pitcher-pr-preview` ApplicationSet on `platform-sthings` picks up the PR and renders Applications targeting `homerun2-pr-<num>` namespace on `homerun2-dev`. |
+| **PR merge / close** | The ApplicationSet drops the entry → ArgoCD prunes child Apps + the PR namespace → a cleanup workflow deletes the PR-tagged GHCR package versions. |
+
+**Preview URL pattern**: `https://omni-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`
+
+**Health check**: `/health` against the URL above returns version/commit/date once the pods are Ready.
+
+The pilot uses a shared k3s preview cluster (`homerun2-dev`) with a wildcard Gateway listener and internal-CA TLS. Reviewers need the `cluster-ca` trusted to suppress browser warnings, or accept the self-signed prompt.
+
+Catalog (where the preview chart lives): [`stuttgart-things/argocd` → `apps/homerun2/install`](https://github.com/stuttgart-things/argocd/tree/main/apps/homerun2/install). Tracking issue: [#108](https://github.com/stuttgart-things/homerun2-omni-pitcher/issues/108).
+
 ## Development
 
 <details>


### PR DESCRIPTION
## Summary

Closes two of the remaining items on #108's task list:

- **`.github/workflows/comment-preview-url.yaml`** — sticky bot comment on PR open/reopen with the preview URL (`https://omni-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`), health endpoint, PR namespace, and ArgoCD link. Idempotent via a `<!-- preview-url-bot -->` marker so reopening doesn't stack duplicates.
- **README "PR preview environments" section** — describes the lifecycle so contributors know what to expect when they open a PR.

## Why on `opened`/`reopened` only

The URL is keyed on PR number, not commit SHA — so the preview URL doesn't change across pushes within the same PR. No reason to re-comment on every `synchronize`.

## Verification

- [x] YAML parses cleanly
- [x] README renders well (table + lifecycle description)
- [ ] After merge: open a no-op PR → confirm the bot posts the expected comment with the right URL

## Related

- ApplicationSet that creates the actual preview env: stuttgart-things/stuttgart-things#2176
- Catalog chart: stuttgart-things/argocd → `apps/homerun2/install`
- Tracking issue: #108

Refs #108