### PR TITLE
feat(ci): restore PR-tagged artifact contract on main

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-omni-pitcher,homerun2-omni-pitcher-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Restores the PR artifact contract that was validated in #109 + #110 but **never actually merged to main** — three workflow files are restored verbatim from the closed pilot branches:

1. **`build-scan-image.yaml`** — adds the `build-pr` job that pushes to **`ghcr.io/stuttgart-things/homerun2-omni-pitcher:pr-<num>-<sha>`** (+ moving tag `pr-<num>`) on PR push. The previous on-main version just ran the default `call-ko-build.yaml` → `ttl.sh` (random 1h tag), which the ArgoCD ApplicationSet can't consume.
2. **`push-kustomize-pr.yaml`** — pushes the kustomize OCI artifact **`ghcr.io/stuttgart-things/homerun2-omni-pitcher-kustomize:pr-<num>-<sha>`** on every PR push. Required by `apps/homerun2/install`'s `omni-pitcher.yaml` template which sources from this repo + tag pinned to `omniPitcher.version`.
3. **`cleanup-pr-artifacts.yaml`** — deletes both packages' `pr-<num>-*` versions on PR close. `dry-run: false` (DELETE permission was already validated in #110).

## Why this slipped

PRs #109 + #110 were intentionally closed (not merged) — they were *validation* PRs to prove the workflows worked end-to-end. The follow-up that should have merged the workflows to main never happened. I missed this when I reviewed #108's status weeks ago and assumed the contract was "shipped".

The gap is visible right now: on `platform-sthings`, every `homerun2-pr-*-omni-pitcher` Application errors with `repository not found` because the expected `pr-<num>-<sha>` tags don't exist on GHCR. Closing PRs doesn't fire any cleanup because the workflow doesn't exist on main.

## Test plan

- [x] Three files are verbatim copies from `origin/test/108-cleanup-no-dryrun` (which had the validated `dry-run: false` flip)
- [ ] After merge, PR #114 (currently in flight) re-runs and publishes `pr-114-<sha>` tags to both GHCR repos
- [ ] ArgoCD `homerun2-pr-114-omni-pitcher` Application transitions from `repository not found` to Synced/Healthy
- [ ] Visit `https://omni-pr-114.homerun2-dev.sthings-vsphere.labul.sva.de/health` → returns version info
- [ ] Close PR #114 → cleanup workflow fires → both `pr-114-*` versions deleted from GHCR

## Related

- ApplicationSet that consumes these artifacts: stuttgart-things/stuttgart-things#2176
- Tracking issue: #108

Refs #108