### PR TITLE
ci(preview): swap inline bot comment for reusable workflow

### DIFF
--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -6,53 +6,11 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-
 jobs:
   comment:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const num = context.issue.number;
-            const url = `https://omni-pr-${num}.homerun2-dev.sthings-vsphere.labul.sva.de`;
-            const marker = "<!-- preview-url-bot -->";
-            const body = [
-              marker,
-              "## 🚀 Preview environment",
-              "",
-              `| | |`,
-              `|--|--|`,
-              `| URL | ${url} |`,
-              `| Health | ${url}/health |`,
-              `| Namespace | \`homerun2-pr-${num}\` on \`homerun2-dev\` |`,
-              `| ArgoCD | [\`homerun2-pr-${num}\`](https://argocd.platform.sthings-vsphere.labul.sva.de/applications?search=homerun2-pr-${num}) |`,
-              "",
-              "Spinning up — give it a couple of minutes for image + kustomize OCI builds to publish and for ArgoCD to sync.",
-              "Closing this PR tears the preview down automatically.",
-            ].join("\n");
-
-            // Sticky comment: update on reopen instead of stacking duplicates.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: num,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: num,
-                body,
-              });
-            }
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: omni-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: homerun2-pr
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Replaces the 60-line inline `actions/github-script` block in `comment-preview-url.yaml` with a thin caller of the new reusable [`call-comment-preview-url.yaml`](https://github.com/stuttgart-things/github-workflow-templates/blob/main/.github/workflows/call-comment-preview-url.yaml) (landed in stuttgart-things/github-workflow-templates#86).

```yaml
jobs:
  comment:
    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
    with:
      hostname-prefix: omni-pr
      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
      namespace-prefix: homerun2-pr
    secrets: inherit  # pragma: allowlist secret
```

The hostname/namespace/ArgoCD conventions now live in one place. Behavior preserved: same marker, same sticky-update logic, same URL/health/namespace/ArgoCD cells.

## Cosmetic delta

The namespace cell drops the " on \`homerun2-dev\`" suffix. The cluster is already implicit in the ArgoCD link host + namespace name; not worth a follow-up template input to preserve.

| Before | After |
|---|---|
| `\`homerun2-pr-117\` on \`homerun2-dev\`` | `\`homerun2-pr-117\`` |

## Motivation

Per #116 step 3, the bot workflow is the one piece still copy-pasted into each component repo (currently omni-pitcher + core-catcher). With this lifted to a reusable, the remaining 7 component rollouts can stay thin: ~10 lines instead of 60.

## Test plan

- [x] YAML valid; caller inputs match the reusable's signature
- [ ] After merge: open a no-op PR on this repo → bot comments fire → sticky behavior intact on reopen