### PR TITLE
feat: bounded startup retry for redis health check

### DIFF
--- a/internal/pitcher/wait.go
+++ b/internal/pitcher/wait.go
@@ -1,0 +1,62 @@
+package pitcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// WaitForReady retries probe with exponential backoff (1s, 2s, 4s, 8s, capped
+// at 16s) until ctx is canceled or probe returns nil. Each attempt runs under
+// a child context with timeout perAttemptTimeout.
+//
+// On success after retries, it logs at info level with the attempt count.
+// On each failed attempt before the budget runs out, it logs at warn level.
+// On budget exhaustion it returns the last probe error wrapped with the
+// attempt count, leaving the os.Exit decision to the caller.
+//
+// Intended use: smooth over short readiness races at startup (Cilium identity
+// propagation in a fresh namespace, sidecar boot delay, etc.) without turning
+// genuine misconfiguration into a silent hang.
+func WaitForReady(ctx context.Context, probe func(context.Context) error, perAttemptTimeout time.Duration) error {
+	const maxBackoff = 16 * time.Second
+	backoff := time.Second
+
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		err := probe(attemptCtx)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				slog.Info("readiness probe succeeded after retries", "attempts", attempt)
+			}
+			return nil
+		}
+		lastErr = err
+
+		if ctx.Err() != nil {
+			return fmt.Errorf("after %d attempts: %w", attempt, lastErr)
+		}
+
+		slog.Warn("readiness probe failed, retrying",
+			"attempt", attempt,
+			"error", err,
+			"next_sleep", backoff.String(),
+		)
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return fmt.Errorf("after %d attempts: %w", attempt, lastErr)
+		}
+
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}

--- a/internal/pitcher/wait_test.go
+++ b/internal/pitcher/wait_test.go
@@ -1,0 +1,100 @@
+package pitcher
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitForReady_FirstTry(t *testing.T) {
+	var calls atomic.Int32
+	probe := func(ctx context.Context) error {
+		calls.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := WaitForReady(ctx, probe, 100*time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("probe calls = %d, want 1 (happy path must not retry)", got)
+	}
+}
+
+func TestWaitForReady_SucceedsAfterRetries(t *testing.T) {
+	var calls atomic.Int32
+	probe := func(ctx context.Context) error {
+		n := calls.Add(1)
+		if n < 3 {
+			return errors.New("not ready yet")
+		}
+		return nil
+	}
+
+	// Use a short stand-in: WaitForReady's first backoff is 1s. Budget of 5s
+	// is enough for two retry sleeps (1s + 2s) plus a hair of slack.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := WaitForReady(ctx, probe, 100*time.Millisecond); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("probe calls = %d, want 3", got)
+	}
+	// First sleep 1s + second sleep 2s = 3s of backoff before the third probe.
+	if elapsed := time.Since(start); elapsed < 2900*time.Millisecond {
+		t.Errorf("elapsed = %v, want at least 2.9s (skipped backoff?)", elapsed)
+	}
+}
+
+func TestWaitForReady_BudgetExhausted(t *testing.T) {
+	var calls atomic.Int32
+	probe := func(ctx context.Context) error {
+		calls.Add(1)
+		return errors.New("redis unreachable")
+	}
+
+	// 50ms budget, 10ms per attempt — guarantees we hit the deadline quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := WaitForReady(ctx, probe, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when budget exhausted, got nil")
+	}
+	if !strings.Contains(err.Error(), "redis unreachable") {
+		t.Errorf("error %q does not wrap last probe error", err.Error())
+	}
+	if !strings.Contains(err.Error(), "after") {
+		t.Errorf("error %q missing attempt-count prefix", err.Error())
+	}
+	if calls.Load() < 1 {
+		t.Error("probe never called")
+	}
+}
+
+func TestWaitForReady_StopsImmediatelyOnContextCancel(t *testing.T) {
+	probe := func(ctx context.Context) error {
+		return errors.New("boom")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	start := time.Now()
+	err := WaitForReady(ctx, probe, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when ctx already canceled")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Errorf("elapsed = %v, want <200ms (did the helper sleep through cancel?)", elapsed)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,8 +44,12 @@ func main() {
 		redisConfig := config.LoadRedisConfig()
 		rp := &pitcher.RedisPitcher{Config: redisConfig}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := rp.HealthCheck(ctx); err != nil {
+		// Bounded retry loop for the startup redis health check. Smooths over
+		// short readiness races (e.g. Cilium identity propagation in a fresh
+		// per-PR namespace, see #121) without masking genuine misconfig — the
+		// process still fails fast once the 30s budget expires.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := pitcher.WaitForReady(ctx, rp.HealthCheck, 5*time.Second); err != nil {
 			slog.Error("redis health check failed", "error", err, "addr", redisConfig.Addr, "port", redisConfig.Port)
 			cancel()
 			os.Exit(1)


### PR DESCRIPTION
## Summary

- Add `pitcher.WaitForReady(ctx, probe, perAttemptTimeout)`: exponential backoff (1s → 2s → 4s → 8s → 16s ceiling) under a caller-controlled context budget. Each failed attempt logs at warn; success after retries logs at info with the attempt count; budget exhaustion returns the last probe error wrapped with the count.
- `main.go` wraps the startup redis health check with a 30s budget and 5s per-attempt timeout. Happy path still fires one probe with no added latency; `os.Exit(1)` still triggers when the budget expires, so genuine misconfig fails fast.
- Unit tests cover happy path (1 call, 0 retries), retry-then-succeed (3 calls, ~3s of backoff), budget exhausted (wraps last error), and already-canceled context (returns immediately, no sleep).

Closes #121. Found during smoke of #120.

## Test plan

- [x] `go test ./...` green; new `WaitForReady` tests verify all four paths.
- [x] `go vet ./...` clean.
- [ ] Preview env (PR labeled `preview`): omni-pitcher pod boots clean on first try once Cilium settles, with at most one or two warn lines before success — no more visible crash-loop on fresh namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)