### PR TITLE
feat: ship HTTPRoute in the kustomize OCI base (Option B for argocd#116)

### DIFF
--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -6,6 +6,15 @@ config.ingressHost: homerun2-omni-pitcher.example.com
 config.ingressTlsEnabled: true
 config.ingressAnnotations:
   cert-manager.io/cluster-issuer: cluster-issuer-approle
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-omni-pitcher.example.com
 config.redisAddr: redis-stack.homerun2.svc.cluster.local
 config.redisPort: "6379"
 config.redisStream: messages


### PR DESCRIPTION
## Summary

Flip `config.httpRouteEnabled` to `true` in the default KCL deploy profile so the omni-pitcher kustomize OCI carries the HTTPRoute alongside the Service. The KCL was already conditional on the flag — this just enables it.

**Why** — stuttgart-things/argocd#116: the per-PR preview env races the Cilium gateway controller when the HTTPRoute is created by one ArgoCD Application before the Service is created by another. Cilium stamps `BackendNotFound` and never re-resolves. Shipping HTTPRoute + Service in the same kustomize apply eliminates the cross-Application race architecturally.

This is **Option B** from the issue. The standalone `apps/homerun2/httproute` child Application becomes redundant once the `apps/homerun2/install` chart adds patches for the kustomize-rendered HTTPRoute (parentRef + hostname per env), which is the argocd-side follow-up.

## Default values

The profile bakes sensible placeholders for the dev cluster (`homerun2-dev-gateway` in `default` ns, hostname `homerun2-omni-pitcher.example.com`). The install chart will patch all three per env.

Consumers without a Gateway API drop the HTTPRoute via a kustomize delete patch (same pattern the chart already uses to delete the rendered Ingress for previews).

## Test plan

- [x] Local KCL render confirms HTTPRoute manifest is emitted (`apiVersion: gateway.networking.k8s.io/v1`, parentRef + hostname + backendRefs.name=`homerun2-omni-pitcher` + port=80).
- [ ] Preview env (with `preview` label): the new kustomize OCI is consumed by `homerun2-pr-<num>-omni-pitcher`; once the chart-side patches land in argocd, HTTPRoute reaches `ResolvedRefs: True` on first reconcile without the manual `kubectl annotate reconcile-bump=...` workaround.

## Follow-up

- `stuttgart-things/argocd#116` — chart-side: add patches to `apps/homerun2/install/templates/omni-pitcher.yaml` for HTTPRoute parentRef/hostname; drop the standalone httproute child Application from the chart and from cluster overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)