### PR TITLE
docs(readme): note preview env requires 'preview' label (Option B smoke)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ When `ROUTES_CONFIG` is unset, the legacy single-stream behavior is preserved (e
 
 ## PR preview environments
 
-Every open PR against `main` gets an ephemeral preview environment on `homerun2-dev` — omni-pitcher + redis-stack in an isolated namespace, reachable end-to-end so reviewers can pitch test events against the PR build.
+Every open PR against `main` carrying the `preview` label gets an ephemeral preview environment on `homerun2-dev` — omni-pitcher + redis-stack in an isolated namespace, reachable end-to-end so reviewers can pitch test events against the PR build.
 
 | Event | What happens |
 |---|---|


### PR DESCRIPTION
## Summary

One-line README clarification. The real intent of this PR is **smoke-testing Option B end-to-end** now that the three coordinating PRs have landed:

- stuttgart-things/homerun2-omni-pitcher#125 (KCL flips HTTPRoute on in the OCI) — merged
- stuttgart-things/argocd#117 (chart adds \`omniPitcher.inlineHttpRoute\` flag) — merged
- stuttgart-things/stuttgart-things#2194 (omni-pitcher AppSet flips the flag) — merged

## Smoke verification checklist

After this PR is labeled \`preview\` and the AppSet reconciles (~10 min):

- [ ] \`homerun2-pr-N-omni-pitcher\` Application reaches \`Synced/Healthy\` on first reconcile
- [ ] \`kubectl -n homerun2-pr-N get httproute homerun2-omni-pitcher -o jsonpath='{.status.parents[0].conditions[?(@.type=="ResolvedRefs")].status}'\` returns \`True\` immediately
- [ ] **No** \`homerun2-pr-N-httproute\` standalone Application exists (omni-pitcher is now excluded from the standalone route list)
- [ ] HTTPRoute resource in the namespace has \`spec.parentRefs[0].name=homerun2-dev-gateway\` + \`spec.hostnames[0]=omni-pr-N.homerun2-dev.sthings-vsphere.labul.sva.de\` (chart-patched via JSON-Patch)
- [ ] Preview URL \`https://omni-pr-N.homerun2-dev.sthings-vsphere.labul.sva.de/health\` responds 200
- [ ] No \`kubectl annotate reconcile-bump=…\` workaround needed

If all check, **stuttgart-things/argocd#116 can be closed for omni-pitcher** (core-catcher + scout follow-ups tracked separately in homerun2-core-catcher#59 + homerun2-scout#55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)