### PR TITLE
fix(kcl): render admission-webhook defaults on HTTPRoute (parentRefs group/kind, backendRefs weight)

### DIFF
--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -22,8 +22,15 @@ httproute = {
             }
     }
     spec: {
+        # group + kind are admission-webhook defaults on parentRefs; rendering
+        # them explicitly avoids drift on every reconcile (Gateway controller
+        # adds them in, ArgoCD compares chart-rendered against live and flags
+        # OutOfSync otherwise). Same shape as stuttgart-things/argocd#114
+        # fix for the standalone httproute chart.
         parentRefs: [
             {
+                group: "gateway.networking.k8s.io"
+                kind: "Gateway"
                 name: config.httpRouteParentRefName
                 if config.httpRouteParentRefNamespace:
                     namespace: config.httpRouteParentRefNamespace
@@ -41,10 +48,15 @@ httproute = {
                         }
                     }
                 ]
+                # group + kind + weight are admission defaults on backendRefs;
+                # rendering them explicitly prevents the same drift.
                 backendRefs: [
                     {
+                        group: ""
+                        kind: "Service"
                         name: config.name
                         port: config.servicePort
+                        weight: 1
                     }
                 ]
             }


### PR DESCRIPTION
## Summary

Render the Gateway API admission-webhook defaults (`parentRefs[].group/kind`, `backendRefs[].group/kind/weight`) in `kcl/httproute.k` so the chart-rendered output matches the live resource and ArgoCD stops flagging the HTTPRoute as `OutOfSync` on every preview reconcile.

## Why

Smoke of stuttgart-things/homerun2-omni-pitcher#126 surfaced the drift: HTTPRoute resolves correctly (Option B's race fix works), but the App is `OutOfSync` because Cilium / Gateway API's admission webhook adds:

```yaml
parentRefs:
- group: gateway.networking.k8s.io  # ← defaulted
  kind: Gateway                     # ← defaulted
  name: homerun2-dev-gateway
  namespace: default
backendRefs:
- group: ""                          # ← defaulted
  kind: Service                      # ← defaulted
  name: homerun2-omni-pitcher
  port: 80
  weight: 1                          # ← defaulted
```

Same shape as stuttgart-things/argocd#114 (which fixed the same drift on the standalone httproute chart). Bringing the kustomize-base HTTPRoute in line.

Companion chart fix: stuttgart-things/argocd PR for `homerun2.httpRouteJSONPatch` to include `group + kind` in the parentRefs replace (otherwise the chart's `op: replace` clobbers what the OCI renders).

## Verified

```
$ kcl run kcl/main.k -D config.httpRouteEnabled=true … | grep -A 25 HTTPRoute
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: homerun2-dev-gateway
    namespace: default
  …
  backendRefs:
  - group: ''
    kind: Service
    name: homerun2-omni-pitcher
    port: 80
    weight: 1
```

## Test plan

- [x] Local KCL render emits both sets of defaults
- [ ] Once merged + argocd-side helper fix merged: a fresh PR preview reaches `Synced/Healthy` (not just Healthy/OutOfSync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)