### PR TITLE
docs(readme): note kustomize OCI ships HTTPRoute (Option B drift-fix smoke)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ Every open PR against `main` carrying the `preview` label gets an ephemeral prev
 
 | Event | What happens |
 |---|---|
-| **PR open / push** | CI builds + pushes `ghcr.io/stuttgart-things/homerun2-omni-pitcher:pr-<num>-<sha>` (image) and `homerun2-omni-pitcher-kustomize:pr-<num>-<sha>` (kustomize OCI). A bot comments the preview URL. |
-| **ArgoCD reconcile** (≤10m) | The `homerun2-omni-pitcher-pr-preview` ApplicationSet on `platform-sthings` picks up the PR and renders Applications targeting `homerun2-pr-<num>` namespace on `homerun2-dev`. |
+| **PR open / push** | CI builds + pushes `ghcr.io/stuttgart-things/homerun2-omni-pitcher:pr-<num>-<sha>` (image) and `homerun2-omni-pitcher-kustomize:pr-<num>-<sha>` (kustomize OCI, includes the HTTPRoute alongside the Service). A bot comments the preview URL. |
+| **ArgoCD reconcile** (≤10m) | The `homerun2-omni-pitcher-pr-preview` ApplicationSet on `platform-sthings` picks up the PR and renders Applications targeting the `homerun2-pr-<num>` namespace on `homerun2-dev`. |
 | **PR merge / close** | The ApplicationSet drops the entry → ArgoCD prunes child Apps + the PR namespace → a cleanup workflow deletes the PR-tagged GHCR package versions. |
 
 **Preview URL pattern**: `https://omni-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`


### PR DESCRIPTION
## Summary

Tiny README copy edit. Real purpose: smoke-test that the Option B drift fixes (argocd#119 + omni-pitcher#127) land a clean \`Synced/Healthy\` preview env.

## Smoke verification

After this PR is labeled \`preview\` and the AppSet reconciles (~10 min):

- [ ] \`homerun2-pr-N-omni-pitcher\` Application reaches **\`Synced/Healthy\`** (not Healthy/OutOfSync) on first reconcile — both drift fixes confirmed working together
- [ ] HTTPRoute \`ResolvedRefs=True\` immediately (Option B's race fix still working)
- [ ] No \`homerun2-pr-N-httproute\` standalone Application
- [ ] Preview URL \`https://omni-pr-N.homerun2-dev.sthings-vsphere.labul.sva.de/health\` returns 200

If all four check, stuttgart-things/argocd#116 can be closed for omni-pitcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)