### PR TITLE
docs(routes): add /pitch/grafana → alerts route for notification-catcher

### DIFF
--- a/examples/routes.yaml
+++ b/examples/routes.yaml
@@ -6,6 +6,7 @@
 streams:
   - messages
   - github-events
+  - alerts
   - grafana-alerts
   - releases
 
@@ -20,7 +21,17 @@ routes:
       endpoint: /pitch/github
     stream: github-events
 
-  # Grafana alerts — webhook payload sets Message.System = receiver name.
+  # Alertmanager + Grafana webhooks for the homerun2-notification-catcher
+  # pipeline. Endpoint-based routing is more robust than label-based for
+  # this case because Alertmanager sets `receiver` to whatever name lives in
+  # the AM config (e.g. "msteams"), not "grafana".
+  # See: stuttgart-things/homerun2-notification-catcher (issue #9).
+  - match:
+      endpoint: /pitch/grafana
+    stream: alerts
+
+  # Legacy Grafana-only path — kept for setups that don't run
+  # notification-catcher. Payload sets Message.System = receiver name.
   - match:
       system: grafana
     stream: grafana-alerts


### PR DESCRIPTION
## Summary

Augments `examples/routes.yaml` with the routing pattern that the **homerun2-notification-catcher** pipeline expects.

- New `alerts` stream in the allowlist.
- New route `endpoint: /pitch/grafana → alerts`, placed *before* the existing `system: grafana → grafana-alerts` rule.

The legacy label-based rule (`system: grafana`) stays as a fallback for setups that don't run notification-catcher.

## Why endpoint-based for this case

Alertmanager sets the webhook payload's `receiver` field to whatever name lives in the AM config (e.g. `"msteams"`), **not** `"grafana"`. So matching on `system: grafana` would silently drop real cluster alerts. URL-path routing (`endpoint: /pitch/grafana`) is the right primary key because it doesn't depend on payload contents.

## Context

Real cluster alerts flow as:

```
Alertmanager ─▶ omni-pitcher /pitch/grafana ─▶ Redis stream "alerts"
                                                      │
                                          notification-catcher
                                                      │
                                                ▶ MS Teams
```

The catcher consumes `alerts` by default (`REDIS_STREAM=alerts`). For that to work, the producer side has to put traffic on the right stream — that's what this example now demonstrates.

Refs: stuttgart-things/homerun2-notification-catcher#9

## Test plan

- [ ] Docs only — no functional change to omni-pitcher
- [ ] Markdown / yaml lint passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)